### PR TITLE
Add Uint8ClampedArray to PNGDataArray union type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ import { DeflateFunctionOptions } from 'pako';
 
 export { DeflateFunctionOptions };
 
-export type PNGDataArray = Uint8Array | Uint16Array;
+export type PNGDataArray = Uint8Array | Uint8ClampedArray | Uint16Array;
 
 export type DecoderInputType = IOBuffer | ArrayBufferLike | ArrayBufferView;
 


### PR DESCRIPTION
This small change will enable to pass raw ImageData objects to the encode method