### PR TITLE
Optimize PNGEncoder's writeDataBytes method

### DIFF
--- a/src/PNGEncoder.ts
+++ b/src/PNGEncoder.ts
@@ -183,10 +183,8 @@ function writeDataBytes(
   slotsPerLine: number,
   offset: number,
 ): number {
-  for (let j = 0; j < slotsPerLine; j++) {
-    newData.writeByte(data[offset++]);
-  }
-  return offset;
+  newData.writeBytes(new Uint8Array(data.buffer, offset, slotsPerLine));
+  return offset + slotsPerLine;
 }
 
 function writeDataUint16(


### PR DESCRIPTION
Use IOBuffer.writeBytes method + a TypedArray view into the source data to write the whole line and avoid additional calls to IOBUffer's ensureAvailable and _updateLastWrittenByte methods